### PR TITLE
DT-1518 Add new create external user success page

### DIFF
--- a/backend/controllers/createUser.js
+++ b/backend/controllers/createUser.js
@@ -40,7 +40,7 @@ const createUserFactory = (getAssignableGroupsApi, createUser, createUrl, search
         await createUser(res.locals, user)
 
         req.session.searchResultsUrl = `${searchUrl}/results?user=${user.email}`
-        res.redirect(`${manageUrl}/${user.email}/details`)
+        res.render('createUserSuccess.njk', { email: user.email, detailsLink: `${manageUrl}/${user.email}/details` })
       } catch (err) {
         if (err.status === 400 && err.response && err.response.body) {
           const { emailError: error, error_description: errorDescription, field } = err.response.body

--- a/backend/controllers/createUser.test.js
+++ b/backend/controllers/createUser.test.js
@@ -56,10 +56,13 @@ describe('create user factory', () => {
         session: {},
       }
 
-      const redirect = jest.fn()
+      const render = jest.fn()
       const locals = jest.fn()
-      await createUser.post(req, { redirect, locals })
-      expect(redirect).toBeCalledWith('/manage-external-users/bob@digital.justice.gov.uk/details')
+      await createUser.post(req, { render, locals })
+      expect(render).toBeCalledWith('createUserSuccess.njk', {
+        detailsLink: '/manage-external-users/bob@digital.justice.gov.uk/details',
+        email: 'bob@digital.justice.gov.uk',
+      })
       expect(createUserApi).toBeCalledWith(locals, {
         email: 'bob@digital.justice.gov.uk',
         firstName: 'bob',
@@ -81,10 +84,13 @@ describe('create user factory', () => {
         session: {},
       }
 
-      const redirect = jest.fn()
+      const render = jest.fn()
       const locals = jest.fn()
-      await createUser.post(req, { redirect, locals })
-      expect(redirect).toBeCalledWith('/manage-external-users/bob@digital.justice.gov.uk/details')
+      await createUser.post(req, { render, locals })
+      expect(render).toBeCalledWith('createUserSuccess.njk', {
+        detailsLink: '/manage-external-users/bob@digital.justice.gov.uk/details',
+        email: 'bob@digital.justice.gov.uk',
+      })
       expect(createUserApi).toBeCalledWith(locals, {
         email: 'bob@digital.justice.gov.uk',
         firstName: 'bob',
@@ -106,10 +112,13 @@ describe('create user factory', () => {
         session: {},
       }
 
-      const redirect = jest.fn()
+      const render = jest.fn()
       const locals = jest.fn()
-      await createUser.post(req, { redirect, locals })
-      expect(redirect).toBeCalledWith('/manage-external-users/bob@digital.justice.gov.uk/details')
+      await createUser.post(req, { render, locals })
+      expect(render).toBeCalledWith('createUserSuccess.njk', {
+        detailsLink: '/manage-external-users/bob@digital.justice.gov.uk/details',
+        email: 'bob@digital.justice.gov.uk',
+      })
       expect(createUserApi).toBeCalledWith(locals, {
         email: 'bob@digital.justice.gov.uk',
         firstName: 'bob',
@@ -131,9 +140,9 @@ describe('create user factory', () => {
         session: {},
       }
 
-      const redirect = jest.fn()
+      const render = jest.fn()
       const locals = jest.fn()
-      await createUser.post(req, { redirect, locals })
+      await createUser.post(req, { render, locals })
       expect(req.session).toEqual({
         searchResultsUrl: '/search-external-users/results?user=bob@digital.justice.gov.uk',
       })

--- a/integration-tests/integration/externaluser.create.spec.js
+++ b/integration-tests/integration/externaluser.create.spec.js
@@ -1,6 +1,7 @@
 const MenuPage = require('../pages/menuPage')
 const UserPage = require('../pages/userPage')
 const AuthUserCreatePage = require('../pages/authUserCreatePage')
+const AuthUserCreateSuccessPage = require('../pages/authUserCreateSuccessPage')
 
 function createUser() {
   const createPage = AuthUserCreatePage.verifyOnPage()
@@ -21,6 +22,9 @@ function createUser() {
       groupCode: 'SOC_NORTH_WEST',
     })
   })
+  const successPage = AuthUserCreateSuccessPage.verifyOnPage()
+  successPage.email().should('contain.text', 'emailnoone@justice.gov.uk')
+  successPage.userDetailsLink().click()
   UserPage.verifyOnPage('Auth Adm')
 }
 

--- a/integration-tests/pages/authUserCreateSuccessPage.js
+++ b/integration-tests/pages/authUserCreateSuccessPage.js
@@ -1,0 +1,11 @@
+const page = require('./page')
+
+const authUserCreateSuccessPage = () =>
+  page('External user created', {
+    email: () => cy.get('[data-qa="email"]'),
+    userDetailsLink: () => cy.get('[data-qa="user-details"]'),
+  })
+
+export default {
+  verifyOnPage: authUserCreateSuccessPage,
+}

--- a/views/createUserSuccess.njk
+++ b/views/createUserSuccess.njk
@@ -1,0 +1,33 @@
+{% extends "./partials/layout.njk" %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+
+{% set title =  "Create an external user success" %}
+
+ {% block beforeContent %}
+   {{ govukBreadcrumbs({
+     items: [
+       { text: "Home", href: homeUrl },
+       { text: "Manage user accounts", href: '/' },
+       { text: "Create an external user", href: '/create-external-user' },
+       { text: title }
+     ]
+   }) }}
+ {% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{ govukPanel({
+          titleText: "External user created",
+          html: "An email has been sent to " + email,
+          attributes: { "data-qa": "email" }
+        }) }}
+        <div class="govuk-body">
+          <a data-qa="user-details" href="{{detailsLink}}" class="govuk-link">View new user details</a>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
The new page provides confirmation of external user creation and a link through to user details page.