### PR TITLE
DT-2441 Improve CSS, breadcrumbs, filter form

### DIFF
--- a/backend/controllers/search.js
+++ b/backend/controllers/search.js
@@ -46,6 +46,8 @@ const searchFactory = (
 
     // stash away the search url in the session to provide in breadcrumbs to go back
     req.session.searchResultsUrl = req.originalUrl
+    delete req.session.searchTitle
+    delete req.session.searchUrl
 
     const [searchResults, caseloads] = await Promise.all([
       searchApi({

--- a/backend/controllers/search.test.js
+++ b/backend/controllers/search.test.js
@@ -149,6 +149,33 @@ describe('search factory', () => {
         dpsSearch: true,
       })
     })
+    it('should delete any previous breadcrumb information but replace url', async () => {
+      const req = {
+        query: { user: 'joe' },
+        flash: jest.fn(),
+        get: jest.fn().mockReturnValue('localhost'),
+        protocol: 'http',
+        originalUrl: '/results',
+        session: {
+          searchResultsUrl:
+            '/search-with-filter-dps-users?user=local&status=ACTIVE&groupCode=&restrictToActiveGroup=true&roleCode=',
+          searchTitle: 'Search for a DPS user (BETA)',
+          searchUrl:
+            '/search-with-filter-dps-users?user=local&status=ACTIVE&groupCode=&restrictToActiveGroup=true&roleCode=',
+        },
+      }
+      const pagination = { offset: 5 }
+      paginationService.getPagination.mockReturnValue(pagination)
+      mockSearchCall()
+      await search.results(req, {
+        render: jest.fn(),
+        locals: { pageable: { offset: 20, size: 10, totalElements: 123 } },
+      })
+
+      expect(req.session.searchResultsUrl).toEqual(req.originalUrl)
+      expect(req.session.searchTitle).toBeUndefined()
+      expect(req.session.searchUrl).toBeUndefined()
+    })
 
     it('should default the active caseload to the group code', async () => {
       const req = {

--- a/backend/controllers/searchWithFilter.js
+++ b/backend/controllers/searchWithFilter.js
@@ -43,6 +43,9 @@ const searchFactory = (
       pageSize,
       pageOffset,
     })
+    req.session.searchResultsUrl = req.originalUrl
+    req.session.searchTitle = searchTitle
+    req.session.searchUrl = req.originalUrl
 
     const results = searchResults.map((user) => ({
       usernameAndEmail: mapUsernameAndEmail(user),

--- a/backend/controllers/searchWithFilter.test.js
+++ b/backend/controllers/searchWithFilter.test.js
@@ -22,7 +22,7 @@ describe('search factory', () => {
       pagingApi,
       '/search-with-filter-dps-users',
       '/manage-dps-users',
-      'Search for a DPS user',
+      'Search for a DPS user (BETA)',
       true,
       allowDownload,
     )
@@ -56,7 +56,7 @@ describe('search factory', () => {
         const render = jest.fn()
         await search(req, { render })
         expect(render).toBeCalledWith('searchWithFilter.njk', {
-          searchTitle: 'Search for a DPS user',
+          searchTitle: 'Search for a DPS user (BETA)',
           searchUrl: '/search-with-filter-dps-users',
           groupOrPrisonDropdownValues: [{ text: 'Moorland HMP', value: 'MDI' }],
           roleDropdownValues: [{ text: 'Access Role Admin', value: 'ACCESS_ROLE_ADMIN' }],
@@ -194,6 +194,19 @@ describe('search factory', () => {
               '/search-with-filter-dps-users/download?user=Andy&status=INACTIVE&roleCode=ACCESS_ROLE_ADMIN&roleCode=ACCESS_ROLE_GENERAL&groupCode=MDI&groupCode=BXI&activeCaseload=MDI&activeCaseload=BXI',
           }),
         )
+      })
+      it('should delete any previous breadcrumb information but replace url', async () => {
+        const req = {
+          ...standardReq,
+          originalUrl: '/search-with-filter-dps-users',
+        }
+
+        const render = jest.fn()
+        await search(req, { render, locals: { user: { maintainAccessAdmin: true } } })
+
+        expect(req.session.searchResultsUrl).toEqual(req.originalUrl)
+        expect(req.session.searchTitle).toEqual('Search for a DPS user (BETA)')
+        expect(req.session.searchUrl).toEqual(req.originalUrl)
       })
     })
     describe('search api call', () => {

--- a/backend/controllers/userDetails.js
+++ b/backend/controllers/userDetails.js
@@ -4,9 +4,9 @@ const userDetailsFactory = (
   removeGroupApi,
   enableUserApi,
   disableUserApi,
-  searchUrl,
+  defaultSearchUrl,
   manageUrl,
-  searchTitle,
+  defaultSearchTitle,
   showExtraUserDetails,
 ) => {
   const stashStateAndRedirectToIndex = (req, res, errors, group, url) => {
@@ -20,6 +20,8 @@ const userDetailsFactory = (
     const hasMaintainAuthUsers = Boolean(res.locals && res.locals.user && res.locals.user.maintainAuthUsers)
     const hasMaintainDpsUsersAdmin = Boolean(res.locals && res.locals.user && res.locals.user.maintainAccessAdmin)
 
+    const searchTitle = req.session.searchTitle ? req.session.searchTitle : defaultSearchTitle
+    const searchUrl = req.session.searchUrl ? req.session.searchUrl : defaultSearchUrl
     const searchResultsUrl = req.session.searchResultsUrl ? req.session.searchResultsUrl : `${searchUrl}/results`
 
     const [user, roles, groups] = await getUserRolesAndGroupsApi(

--- a/integration-tests/integration/dpsuser.manage.spec.js
+++ b/integration-tests/integration/dpsuser.manage.spec.js
@@ -185,9 +185,10 @@ context('DPS user manage functionality', () => {
     })
   })
 
-  it('Should provide breadcrumb link back to search results', () => {
+  it('Should provide breadcrumb link back to search results and start search', () => {
     const userPage = editUser({ nextPage: true })
 
+    userPage.searchBreadcrumb().should('have.attr', 'href', '/search-dps-users')
     userPage
       .searchResultsBreadcrumb()
       .should(
@@ -195,6 +196,15 @@ context('DPS user manage functionality', () => {
         'href',
         '/search-dps-users/results?user=sometext%40somewhere.com&status=ALL&roleCode=&offset=10',
       )
+  })
+
+  it('Should provide breadcrumb link back to search results with filter only', () => {
+    const userPage = editUser({ nextPage: true, fromSearchFilterPage: true })
+
+    userPage
+      .searchBreadcrumb()
+      .should('have.attr', 'href', '/search-with-filter-dps-users?user=ITAG_USER5&status=ALL&roleCode=')
+    userPage.searchResultsBreadcrumb().should('not.exist')
   })
 
   it('Manage your details contain returnTo url for current dps search page', () => {

--- a/integration-tests/pages/dpsUserSearchWithFilterPage.js
+++ b/integration-tests/pages/dpsUserSearchWithFilterPage.js
@@ -16,6 +16,7 @@ const dpsUserSearchWithFilterPage = () =>
       if (text) userFilterInput().type(text)
       else userFilterInput().clear()
       applyFilters().click()
+      return dpsUserSearchWithFilterPage()
     },
     filterWithTag,
     userFilterInput,

--- a/integration-tests/pages/userPage.js
+++ b/integration-tests/pages/userPage.js
@@ -10,6 +10,7 @@ const userPage = (user) =>
     removeRole: (role) => cy.get(`[data-qa="remove-button-${role}"]`),
     removeGroup: (group) => cy.get(`[data-qa="remove-button-${group}"]`),
     searchResultsBreadcrumb: () => cy.get('a[href*="results"]'),
+    searchBreadcrumb: () => cy.get('a[href*="search"]'),
     enableLink: () => cy.get('[data-qa="enable-button"]'),
     changeEmailLink: () => cy.get('[data-qa="amend-link"]'),
     searchLink: () => cy.get('[data-qa="search-link"]'),

--- a/integration-tests/support/dpsuser.helpers.js
+++ b/integration-tests/support/dpsuser.helpers.js
@@ -19,7 +19,7 @@ export const goToResultsPage = ({ isAdmin = false, totalElements = 21, nextPage 
   return results
 }
 
-export const goToSearchWithFilterPage = ({ isAdmin = true, totalElements = 21, size = 10, nextPage }) => {
+export const goToSearchWithFilterPage = ({ isAdmin = true, totalElements = 21, size = 10 }) => {
   const roleCode = isAdmin ? 'MAINTAIN_ACCESS_ROLES_ADMIN' : 'MAINTAIN_ACCESS_ROLES'
   cy.task('stubSignIn', { roles: [{ roleCode }] })
   cy.signIn()
@@ -43,13 +43,15 @@ export const goToSearchWithFilterPage = ({ isAdmin = true, totalElements = 21, s
   return search
 }
 
-export const editUser = ({ isAdmin = false, nextPage }) => {
-  const results = goToResultsPage({ isAdmin, nextPage })
-
+export const editUser = ({ isAdmin = false, fromSearchFilterPage = false, nextPage }) => {
   cy.task('stubDpsUserDetails')
   cy.task(isAdmin ? 'stubDpsUserGetAdminRoles' : 'stubDpsUserGetRoles')
   cy.task('stubEmail', { email: 'ITAG_USER@gov.uk' })
 
-  results.edit('ITAG_USER5')
+  if (fromSearchFilterPage) {
+    goToSearchWithFilterPage({ isAdmin }).filterUser('ITAG_USER5').manageLinkForUser('ITAG_USER5').click()
+  } else {
+    goToResultsPage({ isAdmin, nextPage }).edit('ITAG_USER5')
+  }
   return UserPage.verifyOnPage('Itag User')
 }

--- a/sass/application.scss
+++ b/sass/application.scss
@@ -1,4 +1,5 @@
 $govuk-page-width: 1170px;
+$govuk-global-styles: true;
 @import 'node_modules/govuk-frontend/govuk/all';
 @import 'node_modules/@ministryofjustice/frontend/moj/components/sortable-table/sortable-table';
 @import 'node_modules/@ministryofjustice/frontend/moj/all';
@@ -184,9 +185,3 @@ pre {
   }
 }
 
-/* TODO - should not need this, but font size is 0, but is ok in other apps */
-.moj-filter__selected-heading a {
-  font-size: 20px;
-  margin-bottom: 20px;
-  display: inline-block;
-}

--- a/static/js/search-filter.js
+++ b/static/js/search-filter.js
@@ -1,5 +1,0 @@
-$('.moj-filter__options')
-  .find(':button')
-  .on('click', () => {
-    $('#filter-form').submit()
-  })

--- a/views/searchWithFilter.njk
+++ b/views/searchWithFilter.njk
@@ -29,7 +29,6 @@
 {% block content %}
 
 {% set filterOptionsHtml %}
-  <form id="filter-form" action="{{ searchUrl }}" novalidate>
     {{ govukInput({
       label: { text: "Name or username" if dpsSearch else "Name, username or email address" },
       classes: "govuk-input--width-20",
@@ -122,7 +121,6 @@
         errorMessage: errors | findError('roleCode')
       }) }}
     </div>
-  </form>
 {% endset %}
 
   <div class="govuk-grid-row govuk-body">
@@ -132,7 +130,9 @@
       <div class="govuk-grid-column-full">
         <div class="moj-filter-layout">
         <div class="moj-filter-layout__filter">
+        <form id="filter-form" action="{{ searchUrl }}" novalidate>
           {{ mojFilter(currentFilter | toUserSearchFilter(groupOrPrisonDropdownValues, roleDropdownValues, filterOptionsHtml, showGroupOrPrisonDropdown))}}
+        </form>
         </div>
         <div class="moj-filter-layout__content">
             <div class="govuk-grid-row">
@@ -193,7 +193,6 @@
 {% block bodyEnd %}
   {{ super() }}
   <script src="/assets/accessible-autocomplete.min.js"></script>
-  <script src="/js/search-filter.js"></script>
   <script>
     {%- if showGroupOrPrisonDropdown %}
     accessibleAutocomplete.enhanceSelectElement({

--- a/views/userDetails.njk
+++ b/views/userDetails.njk
@@ -5,14 +5,28 @@
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
  {% block beforeContent %}
+      {% if searchUrl === searchResultsUrl %}
+      {% set breadcrumbs = 
+        [
+          { text: "Home", href: homeUrl },
+          { text: "Manage user accounts", href: '/' },
+          { text: searchTitle, href: searchUrl },
+          { text: staff.name}
+        ]
+       %}
+      {% else %}
+      {% set breadcrumbs = 
+        [
+          { text: "Home", href: homeUrl },
+          { text: "Manage user accounts", href: '/' },
+          { text: searchTitle, href: searchUrl },
+          { text: "Search results", href: searchResultsUrl },
+          { text: staff.name}
+        ]
+       %}
+     {% endif %}
    {{ govukBreadcrumbs({
-     items: [
-       { text: "Home", href: homeUrl },
-       { text: "Manage user accounts", href: '/' },
-       { text: searchTitle, href: searchUrl },
-       { text: "Search results", href: searchResultsUrl },
-       { text: staff.name}
-     ]
+     items: breadcrumbs
    }) }}
  {% endblock %}
 


### PR DESCRIPTION
3 unrelated improvements to previous PR
* Fix CSS to remove moj filter hack - ensure <p> are styled correctly with the govuk global flag
* Fix need for JavaScript to submit filter form - move form up a level
* Improved breadcrumb handling on edit user - breadcrumbs differ when navigating from the combined filter page