### PR TITLE
DT-2441 Typo and attempt to fix flacky test

### DIFF
--- a/backend/routes/searchApiFactory.test.js
+++ b/backend/routes/searchApiFactory.test.js
@@ -117,7 +117,7 @@ describe('Search API Factory', () => {
         user: { maintainAccessAdmin: true },
       })
     })
-    it('will get normal roles with admin role context', async () => {
+    it('will get normal roles without admin role context', async () => {
       prisonApi.getRolesAdmin.mockResolvedValue([])
 
       await searchableRoles({ user: { maintainAccessAdmin: false } })

--- a/integration-tests/integration/externaluser.search.spec.js
+++ b/integration-tests/integration/externaluser.search.spec.js
@@ -332,6 +332,9 @@ context('External user search functionality', () => {
           validateCsv(output)
         })
       })
+      // attempt to ensure with go any other page except '/' which is where we go after
+      // csv download - else next test fail to signin since we are already at '/'
+      AuthUserSearchPage.goTo()
     })
 
     it('Should not show the download link for group managers', () => {


### PR DESCRIPTION
Fixed type in test.
Attempt to fix flaky test that seems to redirect back to '/' around same time as next test starts causing the fake signing to fail. So adding an extract visit prior to next step